### PR TITLE
prevent dark backgound from breaking on cards that need scrolling

### DIFF
--- a/src/main.scss
+++ b/src/main.scss
@@ -100,6 +100,7 @@ html, body {
 
 .container.dark {
     background: #1d1f21;
+    overflow-x: scroll;
 
     .task-input {
         background: #292c2f;


### PR DESCRIPTION
You can test this with the current dark theme for kanelm: add as many cards as you can until you get the vertical scroll bar. You should notice the background ending and newer cards will have no background.